### PR TITLE
Fix parameter parsing logic in some functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: PROsetta
 Type: Package
 Title: Linking Patient-Reported Outcomes Measures
-Version: 0.1.4
-Date: 2020-06-30
+Version: 0.2.0
+Date: 2020-08-25
 Authors@R: c(
     person("Seung W.", "Choi",
         email = "schoi@austin.utexas.edu",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# PROsetta 0.2.0
+
+## New features
+
+* `runLinking()` now supports `method = 'CP'` to perform two-dimensional calibration, for use in performing calibrated projection ([Thissen et al., 2011](https://doi.org/10.1007/s11136-011-9874-y)).
+* `runLinking()` now supports `method = 'CPLA'` to perform two-dimensional calibration, for use in performing linear approximation of calibrated projection ([Thissen et al., 2015](https://doi.org/10.1007/978-3-319-19977-1_1)).
+* `runRSSS()` now performs two-dimensional Lord-Wingersky recursion with numerical integration, when the output from `runLinking(method = 'CP')` is supplied.
+* `runRSSS()` now performs linear approximation of calibrated projection, when the output from `runLinking(method = 'CPLA')` is supplied.
+* Shiny application `PROsetta()` now supports calibrated projection and its linear approximation.
+
 # PROsetta 0.1.4
 
 * Initial public release.

--- a/R/core_functions.R
+++ b/R/core_functions.R
@@ -521,16 +521,23 @@ getProb <- function(ipar, model, theta_grid) {
 
 #' @noRd
 getEscoreTheta = function(ipar, model, theta, is_minscore_0) {
+
   pp <- getProb(ipar, "grm", theta)
-  pp <- do.call(rbind, pp)
-  ni <- dim(pp)[1]
-  nc <- dim(pp)[2]
-  w  <- matrix(rep(1:nc - 1, ni), ni, nc, byrow = TRUE)
-  e  <- sum(pp * w)
+
+  e  <- lapply(pp, function(x) {
+    sum(x * 0:(length(x) - 1))
+  })
+
+  e  <- do.call(c, e)
+  ni <- length(e)
+  e  <- sum(e)
+
   if (!is_minscore_0) {
     e <- e + ni
   }
+
   return(e)
+
 }
 
 #' @noRd

--- a/R/core_functions.R
+++ b/R/core_functions.R
@@ -397,7 +397,10 @@ getProb <- function(ipar, model, theta_grid) {
 
   dimensions <- detectDimensions(ipar)
   ni         <- nrow(ipar)
-  max_cat    <- dim(ipar)[2] - dimensions + 1
+  ncat       <- apply(ipar, 1, function(x) {
+    sum(!is.na(x)) - dimensions + 1
+  })
+  max_cat    <- max(ncat)
   nq         <- nrow(theta_grid)
 
   p_type     <- detectParameterization(ipar)
@@ -410,13 +413,9 @@ getProb <- function(ipar, model, theta_grid) {
       par_b <- ipar[, dimensions + 1:(max_cat - 1)]
     }
 
-    ncat <- apply(par_b, 1, function(x) {
-      sum(!is.na(x)) + 1
-    })
-
     pp <- list()
     for (i in 1:ni) {
-      pp[[i]] <- matrix(NA, nq, max_cat)
+      pp[[i]] <- matrix(NA, nq, ncat[i])
     }
 
     if (model == "grm") {
@@ -476,6 +475,7 @@ getProb <- function(ipar, model, theta_grid) {
     ncat <- apply(par_d, 1, function(x) {
       sum(!is.na(x)) + 1
     })
+    max_cat <- max(ncat)
 
     pp <- list()
     for (i in 1:ni) {

--- a/R/linking_functions.R
+++ b/R/linking_functions.R
@@ -295,7 +295,7 @@ runEquateObserved <- function(data, scale_from = 2, scale_to = 1, type_to = "raw
       tmp <- merge(
         tmp, rsss[[as.character(scale_to)]],
         by.x = "total", by.y = sprintf("raw_%i", scale_to))
-      tmp <- tmp[, c("theta", "count")]
+      tmp <- tmp[, c("eap", "count")]
       freq_to <- equate::as.freqtab(tmp)
     } else {
       stop("argument 'type_to': 'theta' requires argument 'rsss' to be supplied to be able to map raw scores to theta")

--- a/R/linking_functions.R
+++ b/R/linking_functions.R
@@ -381,7 +381,6 @@ runRSSS <- function(data, ipar_linked, prior_mean = 0.0, prior_sd = 1.0, min_the
     stop(sprintf("argument 'min_score': length(min_score) must be either 1 or %i", n_scale + 1))
   }
 
-  is_minscore_0 <- F
   theta_grid <- getThetaGrid(dimensions, min_theta, max_theta, inc)
 
   # the last item_par_by_scale is the combined scale

--- a/README.Rmd
+++ b/README.Rmd
@@ -42,4 +42,4 @@ Install the latest release from CRAN:
 install.packages("PROsetta")
 ```
 
-The documentation is available at (https://choi-phd.github.io/PROsetta/index.html)
+The documentation is available at (https://choi-phd.github.io/PROsetta)

--- a/README.md
+++ b/README.md
@@ -53,4 +53,4 @@ install.packages("PROsetta")
 ```
 
 The documentation is available at
-(<https://choi-phd.github.io/PROsetta/index.html>)
+(<https://choi-phd.github.io/PROsetta>)

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,10 +1,4 @@
-# PROsetta v0.1.4
-This is a resubmission. In this version:
-
-* Removed \dontrun blocks in the example sections of dataset_asq.Rd and dataset_dep.Rd
-* Rewrote dataset_asq.Rd and dataset_dep.Rd to use consistent documentation style
-* Removed newlines to make the code diff-friendly
-* Examples in runRSSS now use \donttest to reduce CPU time
+# PROsetta 0.2.0
 
 ## Test environments
 
@@ -16,10 +10,8 @@ This is a resubmission. In this version:
 ## R CMD check results
 
 ```
-Status: 1 NOTE
+Status: OK
 
-* checking CRAN incoming feasibility ... NOTE
+* checking CRAN incoming feasibility ... Note_to_CRAN_maintainers
 Maintainer: 'Seung W. Choi <schoi@austin.utexas.edu>'
-
-New submission
 ```

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -10,7 +10,7 @@ citEntry(
     person("David", "Cella")
   ),
   year = 2020,
-  note = "R package version 0.1.4",
+  note = "R package version 0.2.0",
   url = "https://CRAN.R-project.org/package=PROsetta",
   textVersion = paste(
     "Choi, S. W., Lim, S., Schalet, B. D., Kaat, A. J., Cella, D.",

--- a/tests/testthat/test_runLinking.R
+++ b/tests/testthat/test_runLinking.R
@@ -6,6 +6,9 @@ test_that("runLinking", {
 
   skip_on_cran()
   skip_on_travis()
+  skip_on_os("mac")
+  skip_on_os("linux")
+  skip_on_os("solaris")
 
   # Hard-coded values are from Windows
 

--- a/tests/testthat/test_runRSSS.R
+++ b/tests/testthat/test_runRSSS.R
@@ -6,6 +6,9 @@ test_that("runRSSS", {
 
   skip_on_cran()
   skip_on_travis()
+  skip_on_os("mac")
+  skip_on_os("linux")
+  skip_on_os("solaris")
 
   set.seed(1)
   calib <- runLinking(d, method = "FIXEDPAR", technical = list(NCYCLES = 1000))


### PR DESCRIPTION
This update fixes parameter parsing logic in some functions.

* `getProb()` and `getEscoreTheta()` now read number of response categories correctly.
* `runEquateObserved(method = "theta")` now works.
* `runRSSS()` now accepts 2D calibration results from `runCalibration()`.
* Some tests are now skipped on non-Windows systems.