### PR TITLE
Fix column detection logic

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: PROsetta
 Type: Package
 Title: Linking Patient-Reported Outcomes Measures
-Version: 0.3.0
-Date: 2021-04-13
+Version: 0.3.1
+Date: 2021-06-10
 Authors@R: c(
     person("Seung W.", "Choi",
         email = "schoi@austin.utexas.edu",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# PROsetta 0.3.1
+
+## Bug fixes
+* Fixed where `runCalibration(fixedpar = TRUE)` was not reading anchor parameters correctly when an integer value existed in anchor parameters.
+
 # PROsetta 0.3.0
 
 ## New features

--- a/R/core_functions.R
+++ b/R/core_functions.R
@@ -99,7 +99,7 @@ getAnchorPar <- function(d, as_AD) {
   idx <- c()
   for (j in 1:dim(d@anchor)[2]) {
     if (inherits(d@anchor[, j], "numeric")) {
-      if (all(d@anchor[, j] != round(d@anchor[, j]), na.rm = TRUE)) {
+      if (any(d@anchor[, j] != round(d@anchor[, j]), na.rm = TRUE)) {
         idx <- c(idx, j)
       }
     }

--- a/README.Rmd
+++ b/README.Rmd
@@ -42,4 +42,4 @@ Install the latest release from CRAN:
 install.packages("PROsetta")
 ```
 
-The documentation is available at (https://choi-phd.github.io/PROsetta)
+The documentation is available at (https://choi-phd.github.io/PROsetta/)

--- a/README.md
+++ b/README.md
@@ -53,4 +53,4 @@ install.packages("PROsetta")
 ```
 
 The documentation is available at
-(<https://choi-phd.github.io/PROsetta>)
+(<https://choi-phd.github.io/PROsetta/>)

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -10,12 +10,13 @@ citEntry(
     person("David", "Cella")
   ),
   year = 2020,
-  note = "R package version 0.2.0",
+  note = sprintf("R package version %s", meta$Version),
   url = "https://CRAN.R-project.org/package=PROsetta",
   textVersion = paste(
     "Choi, S. W., Lim, S., Schalet, B. D., Kaat, A. J., Cella, D.",
     "(2020).",
-    "PROsetta: Linking Patient-Reported Outcomes Measures. R package version 0.2.0.",
+    "PROsetta: Linking Patient-Reported Outcomes Measures.",
+    sprintf("R package version %s.", meta$Version),
     "https://CRAN.R-project.org/package=PROsetta"
   )
 )


### PR DESCRIPTION
- fix where `runCalibration(fixedpar = TRUE)` was not reading anchor parameters correctly when an integer value existed in anchor parameters.