### PR TITLE
fix for some cases

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: PROsetta
 Type: Package
 Title: Linking Patient-Reported Outcomes Measures
-Version: 0.3.1
+Version: 0.3.1.9000
 Date: 2021-06-10
 Authors@R: c(
     person("Seung W.", "Choi",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# PROsetta 0.3.2
+
+* Fixed where `runLinking(method = "FIXEDPAR")` was not working when the anchor instrument ID was not 1 in item map.
+* Fixed where `runLinking(method = "FIXEDPAR")` was not working when the anchor and target instruments had different numbers of categories in response data.
+* Fixed where `runFrequency()` was not sorting categories correctly when the number of categories was 10 or above.
+
 # PROsetta 0.3.1
 
 ## Bug fixes

--- a/R/configPROsetta.R
+++ b/R/configPROsetta.R
@@ -253,7 +253,8 @@ runFrequency <- function(data, check_frequency = TRUE) {
   tmp <- apply(resp_data, 2, table)
 
   if (inherits(tmp, "list")) {
-    catnames <- sort(unique(do.call(c, lapply(tmp, names))))
+    catnames <- unique(do.call(c, lapply(tmp, names)))
+    catnames <- sort(as.numeric(catnames))
     freq <- as.data.frame(matrix(NA, length(tmp), length(catnames)))
     colnames(freq) <- catnames
     rownames(freq) <- names(tmp)

--- a/R/core_functions.R
+++ b/R/core_functions.R
@@ -210,6 +210,12 @@ fixParLayout <- function(par_layout, d) {
   }
 
   ipar_anchor    <- getAnchorPar(d, as_AD = TRUE)
+  if (dimensions == 1 & (!"a1" %in% names(ipar_anchor))) {
+    # if using a 1D model and the anchor dimension is not 1
+    a_par_name <- sprintf("a%s", getAnchorDimension(d))
+    a_par_idx  <- which(names(ipar_anchor) == a_par_name)
+    names(ipar_anchor)[a_par_idx] <- "a1"
+  }
   par_to_fix     <- which(par_layout$item %in% rownames(ipar_anchor))
   n_items_to_fix <- length(unique(par_layout$item[par_to_fix]))
   par_layout$est[par_to_fix] <- FALSE

--- a/R/linking_functions.R
+++ b/R/linking_functions.R
@@ -248,8 +248,8 @@ runLinking <- function(data, method, ...) {
     out$method      <- method
     rownames(out$ipar_linked) <- id_new$ID
     rownames(out$ipar_anchor) <- id_old$ID
-    colnames(out$ipar_linked) <- colnames(ipar)
-    colnames(out$ipar_anchor) <- colnames(ipar)
+    colnames(out$ipar_linked) <- colnames(ipar)[1:dim(out$ipar_linked)[2]]
+    colnames(out$ipar_anchor) <- colnames(ipar)[1:dim(out$ipar_anchor)[2]]
 
     return(out)
 


### PR DESCRIPTION
* Fixed where `runLinking(method = "FIXEDPAR")` was not working when the anchor instrument ID was not 1 in item map.
* Fixed where `runLinking(method = "FIXEDPAR")` was not working when the anchor and target instruments had different numbers of categories in response data.
* Fixed where `runFrequency()` was not sorting categories correctly when the number of categories was 10 or above.