### PR TITLE
`loadData()`: fix correlation check

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,15 @@
 # PROsetta 0.4.1.9000
 
+## New features
+
 * Added support for working with GPC models.
 * Added support for when items between instruments have different item models. (e.g., the anchoring instrument uses GR, and the instrument being calibrated uses GPC.)
 * Added support for when items within the anchoring instrument use different item models. (e.g., the anchoring instrument uses GR for some items and GPC for others.)
 * Added support for when items within the instrument being calibrated use different item models. (e.g., the instrument being calibrated uses GR for some items and GPC for others.)
+
+## Bug fixes
+
+* Fixed where `loadData()` would not warn about items that may need reverse coding for scale IDs other than 1.
 
 # PROsetta 0.4.1
 

--- a/R/loading_functions.R
+++ b/R/loading_functions.R
@@ -218,8 +218,8 @@ loadData <- function(
   data@scale_id  <- scale_id
   data@model_id  <- model_id
 
-  for (s in unique(data@itemmap[[scale_id]])) {
-    cor_matrix <- cor(getResponse(data, 1), use = "pairwise.complete.obs")
+  for (this_scale in unique(data@itemmap[[scale_id]])) {
+    cor_matrix <- cor(getResponse(data, this_scale), use = "pairwise.complete.obs")
     reverse_code_check <- apply(cor_matrix, 1, sum) < 0
     if (any(reverse_code_check)) {
       potentially_not_reverse_coded_items <- names(which(reverse_code_check))


### PR DESCRIPTION
## Description

- Fixed where `loadData()` would not warn about items that may need reverse coding for scale IDs other than 1.